### PR TITLE
Specify options through interactive prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
-- `@inrupt/generate-oidc-token` can now be used with `npx`
+- `@inrupt/generate-oidc-token` can now be used with `npx`.
+- An interactive prompt helps the user provide the relevant options.
 
 The following sections document changes that have been released already:

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,9 +453,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.2.4.tgz",
-      "integrity": "sha512-XtUfRmJ41kANbD5lL6zAByDvRIgPohq7Y7I8kPNVKuiKqEucJDgWJ1O1+RH42I07JkZORKEvG7xQ0DYdOLbKdA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.2.5.tgz",
+      "integrity": "sha512-Vk1N0tg8tQ8lrw9Z1tgJ7dnHwfLrCt/XHvLZaVOgMTbnQH9NfHWX7u5qMqrG8WPZyd3OThQXWBBORhVt/8lXtA==",
       "requires": {
         "@inrupt/solid-common-vocab": "^0.5.2",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -467,11 +467,11 @@
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.2.4.tgz",
-      "integrity": "sha512-Bwvc+ipngTrhckY9Sw/YwVMRzw0kzbyO6sc4zw6wnTFzbs0smbDgNs/XdEmYMAYRoYZg4gYnFOy44GJh10aXVQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.2.5.tgz",
+      "integrity": "sha512-iX6IrxgugIFPtUxPyDfApSv6b/83M4gx4/EpOsbLB6hxPGoK0AKlJo9FiTDQg2zZ8gldvjk+SST/O95/t+KckA==",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.2.4",
+        "@inrupt/solid-client-authn-core": "^1.2.5",
         "@types/node": "^14.14.14",
         "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.0.6",
@@ -888,6 +888,16 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
       "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
     },
+    "@types/inquirer": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.1.tgz",
+      "integrity": "sha512-osD38QVIfcdgsPCT0V3lD7eH0OFurX71Jft18bZrsVQWVRt6TuxRzlr0GJLrxoHZR2V5ph7/qP8se/dcnI7o0g==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -1021,6 +1031,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/uuid": {
       "version": "8.3.0",
@@ -1204,7 +1223,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
       "requires": {
         "type-fest": "^0.11.0"
       },
@@ -1212,8 +1230,7 @@
         "type-fest": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
         }
       }
     },
@@ -1661,7 +1678,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1672,6 +1688,11 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -1717,7 +1738,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -1773,6 +1793,11 @@
           }
         }
       }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -2267,8 +2292,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -2730,6 +2754,16 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -2853,7 +2887,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -3159,8 +3192,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3363,6 +3395,48 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -4607,8 +4681,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -4790,8 +4863,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -4848,6 +4920,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5072,7 +5149,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -5121,8 +5197,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
@@ -5698,7 +5773,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -5731,6 +5805,11 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
     "run-parallel": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
@@ -5741,7 +5820,6 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -6048,8 +6126,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -6501,7 +6578,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -6570,8 +6646,15 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "tmpl": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "check-licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
-    "lint": "eslint --config .eslintrc.js --fix"
+    "lint": "eslint --config .eslintrc.js --fix; prettier --write src/*"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/inrupt/generate-oidc-token#readme",
   "devDependencies": {
     "@types/express": "^4.17.9",
+    "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.19",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
@@ -51,8 +52,9 @@
     "*.{ts,tsx,js,jsx,css,md,mdx}": "prettier --write"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-node": "^1.2.4",
+    "@inrupt/solid-client-authn-node": "^1.2.5",
     "express": "^4.17.1",
+    "inquirer": "^7.3.3",
     "yargs": "^16.2.0"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export const IDP_POD_INRUPT = "https://broker.pod.inrupt.com";
-export const IDP_POD_COMPAT = "https://broker.pod-compat.inrupt.com";
+export const IDENTITY_PROVIDER_INRUPT_PROD = "https://broker.pod.inrupt.com";
+export const IDENTITY_PROVIDER_INRUPT_PROD_COMPAT =
+  "https://broker.pod-compat.inrupt.com";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export const IDP_POD_INRUPT = "https://broker.pod.inrupt.com";
+export const IDP_POD_COMPAT = "https://broker.pod-compat.inrupt.com";

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,14 +37,14 @@ import {
 
 type InputOptions = {
   solidIdentityProvider?: string;
-  clientName?: string;
+  applicationName?: string;
   registrationType?: "static" | "dynamic";
 };
 
 type ValidatedOptions = {
   solidIdentityProvider: string;
+  applicationName?: string;
   registrationType: "static" | "dynamic";
-  clientName?: string;
 };
 
 async function main(): Promise<void> {
@@ -55,7 +55,10 @@ async function main(): Promise<void> {
       "The identity provider at which the user should authenticate."
     )
     .alias("idp", "solidIdentityProvider")
-    .describe("appName", "The name of the app you are registering.")
+    .describe(
+      "applicationName",
+      "The name of the client application you whish to register."
+    )
     .describe(
       "registration",
       "[static] if you want to manually register the client, [dynamic] otherwise."
@@ -69,7 +72,7 @@ async function main(): Promise<void> {
 
   const inputOptions: InputOptions = {
     ...argv,
-    clientName: argv.appName,
+    clientName: argv.applicationName,
   };
   // Complete CLI arguments with user prompt
   const validatedOptions: ValidatedOptions = {
@@ -77,7 +80,7 @@ async function main(): Promise<void> {
       inputOptions.solidIdentityProvider ?? (await promptIdp()),
     registrationType:
       inputOptions.registrationType ?? (await promptRegistration()),
-    clientName: inputOptions.clientName ?? (await promptClientName()),
+    applicationName: inputOptions.applicationName ?? (await promptClientName()),
   };
   const port = argv.port ?? (await promptPort());
 
@@ -93,7 +96,7 @@ async function main(): Promise<void> {
   const server = app.listen(port, async () => {
     console.log(`Listening at: [${iriBase}].`);
     const loginOptions: ILoginInputOptions = {
-      clientName: validatedOptions.clientName,
+      clientName: validatedOptions.applicationName,
       oidcIssuer: validatedOptions.solidIdentityProvider,
       redirectUrl: iriBase,
       tokenType: "DPoP",

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
     console.log(`Client Secret: [${storedSession.clientSecret}]`);
 
     res.send(
-      "The tokens have been sent to the bootstraping app. You can close this window."
+      "The tokens have been sent to @inrupt/generate-oidc-token. You can close this window."
     );
     server.close();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ async function main(): Promise<void> {
     )
     .describe(
       "port",
-      "The port number on which the identity provider will return the token."
+      "@inrupt/generate-oidc-token will start a local web server, in order for the Solid Identity Provider to redirect the user back after they log in. This  is the port number to which this local server will be bound."
     )
     .locale("en")
     .help().argv;

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,11 @@ async function main(): Promise<void> {
     let clientInfo;
     if (validatedOptions.registrationType === "static") {
       console.log(
-        `Please go perform the static registration of your application to [${validatedOptions.solidIdentityProvider}].`
+        `Please perform static registration of your application at the Solid Identity Provider [${validatedOptions.solidIdentityProvider}].`
       );
-      console.log(`The redirect IRI will be ${iriBase}`);
+      console.log(
+        `The redirect IRI will be [${iriBase}] (you will need this information when registering your application).`
+      );
       console.log(
         "At the end of the registration process, you should get a client ID and secret."
       );
@@ -121,10 +123,14 @@ async function main(): Promise<void> {
     }
 
     console.log(
-      `Logging in ${validatedOptions.solidIdentityProvider} to get a refresh token.`
+      `Logging into Solid Identity Provider  ${validatedOptions.solidIdentityProvider} to get a refresh token.`
     );
     session.login(loginOptions).catch((e) => {
-      throw new Error(`Login failed: ${e.toString()}`);
+      throw new Error(
+        `Logging into Solid Identity Provider [${
+          validatedOptions.solidIdentityProvider
+        }] failed: ${e.toString()}`
+      );
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,72 +20,131 @@
  */
 
 // The only import we need from the Node AuthN library is the Session class.
-import { Session, InMemoryStorage } from "@inrupt/solid-client-authn-node";
-
-const argv = require("yargs/yargs")(process.argv.slice(2))
-  .describe(
-    "oidcIssuer",
-    "The identity provider at which the user should authenticate."
-  )
-  .alias("issuer", "oidcIssuer")
-  .describe("clientName", "The name of the bootstrapped app.")
-  .demandOption(["oidcIssuer"])
-  .locale("en")
-  .help().argv;
-
+import {
+  Session,
+  InMemoryStorage,
+  ILoginInputOptions,
+} from "@inrupt/solid-client-authn-node";
 import express from "express";
-const app = express();
-const PORT = 3001;
-const iriBase = `http://localhost:${PORT}`;
-const storage = new InMemoryStorage();
 
-// Initialised when the server comes up and is running...
-let session: Session;
+import {
+  promptClientName,
+  promptIdp,
+  promptPort,
+  promptRegistration,
+  promptStaticClientInfo,
+} from "./prompts";
 
-const server = app.listen(PORT, async () => {
-  session = new Session({
+type InputOptions = {
+  identityProvider?: string;
+  clientName?: string;
+  registrationType?: ["static, dynamic"];
+};
+
+type ValidatedOptions = {
+  identityProvider: string;
+  registrationType: "static" | "dynamic";
+  clientName?: string;
+};
+
+async function main(): Promise<void> {
+  // Get CLI arguments
+  const argv = require("yargs/yargs")(process.argv.slice(2))
+    .describe(
+      "identityProvider",
+      "The identity provider at which the user should authenticate."
+    )
+    .alias("idp", "identityProvider")
+    .describe("clientName", "The name of the bootstrapped app.")
+    .describe(
+      "registration",
+      "[static] if you want to manually register the client, [dynamic] otherwise."
+    )
+    .describe(
+      "port",
+      "The port number on which the identity provider will return the token."
+    )
+    .locale("en")
+    .help().argv;
+
+  const inputOptions: InputOptions = argv;
+  // Complete CLI arguments with user prompt
+  const validatedOptions: ValidatedOptions = {
+    identityProvider: inputOptions.identityProvider ?? (await promptIdp()),
+    registrationType:
+      inputOptions.registrationType ?? (await promptRegistration()),
+    clientName: inputOptions.clientName ?? (await promptClientName()),
+  };
+  const port = argv.port ?? (await promptPort());
+
+  const app = express();
+  const iriBase = `http://localhost:${port}`;
+  const storage = new InMemoryStorage();
+
+  const session: Session = new Session({
     insecureStorage: storage,
     secureStorage: storage,
   });
 
-  console.log(`Listening at: [http://localhost:${PORT}].`);
-  console.log(`Logging in ${argv.oidcIssuer} to get a refresh token.`);
-  session
-    .login({
-      clientName: argv.clientName,
-      oidcIssuer: argv.oidcIssuer,
+  const server = app.listen(port, async () => {
+    console.log(`Listening at: [${iriBase}].`);
+    const loginOptions: ILoginInputOptions = {
+      clientName: validatedOptions.clientName,
+      oidcIssuer: validatedOptions.identityProvider,
       redirectUrl: iriBase,
       tokenType: "DPoP",
       handleRedirect: (url) => {
         console.log(`\nPlease visit ${url} in a web browser.\n`);
       },
-    })
-    .catch((e) => {
+    };
+    let clientInfo;
+    if (validatedOptions.registrationType === "static") {
+      console.log(
+        `Please go perform the static registration of your application to [${validatedOptions.identityProvider}].`
+      );
+      console.log(`The redirect IRI will be ${iriBase}`);
+      console.log(
+        "At the end of the registration process, you should get a client ID and secret."
+      );
+      clientInfo = await promptStaticClientInfo();
+      loginOptions.clientId = clientInfo.clientId;
+      loginOptions.clientSecret = clientInfo.clientSecret;
+    }
+
+    console.log(
+      `Logging in ${validatedOptions.identityProvider} to get a refresh token.`
+    );
+    session.login(loginOptions).catch((e) => {
       throw new Error(`Login failed: ${e.toString()}`);
     });
-});
+  });
 
-app.get("/", async (_req, res) => {
-  console.log("Login successful.");
-  await session.handleIncomingRedirect(`${iriBase}${_req.url}`);
-  // NB: This is a temporary approach, and we have work planned to properly
-  // collect the token. Please note that the next line is not part of the public
-  // API, and is therefore likely to break on non-major changes.
-  const rawStoredSession = await storage.get(
-    `solidClientAuthenticationUser:${session.info.sessionId}`
-  );
-  if (rawStoredSession === undefined) {
-    throw new Error(
-      `Cannot find session with ID [${session.info.sessionId}] in storage.`
+  app.get("/", async (_req, res) => {
+    console.log("Login successful.");
+    await session.handleIncomingRedirect(`${iriBase}${_req.url}`);
+    // NB: This is a temporary approach, and we have work planned to properly
+    // collect the token. Please note that the next line is not part of the public
+    // API, and is therefore likely to break on non-major changes.
+    const rawStoredSession = await storage.get(
+      `solidClientAuthenticationUser:${session.info.sessionId}`
     );
-  }
-  const storedSession = JSON.parse(rawStoredSession);
-  console.log(`\nRefresh token: [${storedSession.refreshToken}]`);
-  console.log(`Client ID: [${storedSession.clientId}]`);
-  console.log(`Client Secret: [${storedSession.clientSecret}]`);
+    if (rawStoredSession === undefined) {
+      throw new Error(
+        `Cannot find session with ID [${session.info.sessionId}] in storage.`
+      );
+    }
+    const storedSession = JSON.parse(rawStoredSession);
+    console.log(`\nRefresh token: [${storedSession.refreshToken}]`);
+    console.log(`Client ID: [${storedSession.clientId}]`);
+    console.log(`Client Secret: [${storedSession.clientSecret}]`);
 
-  res.send(
-    "The tokens have been sent to the bootstraping app. You can close this window."
-  );
-  server.close();
-});
+    res.send(
+      "The tokens have been sent to the bootstraping app. You can close this window."
+    );
+    server.close();
+  });
+}
+
+// Asynchronous operations are required to get user prompt, and top-level await
+// are not supported yet, which is why an async main is used.
+void main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,10 @@ import {
 import express from "express";
 
 import {
-  promptClientName,
-  promptIdp,
+  promptApplicationName,
+  promptSolidIdentityProvider,
   promptPort,
-  promptRegistration,
+  promptRegistrationType,
   promptStaticClientInfo,
 } from "./prompts";
 
@@ -77,10 +77,12 @@ async function main(): Promise<void> {
   // Complete CLI arguments with user prompt
   const validatedOptions: ValidatedOptions = {
     solidIdentityProvider:
-      inputOptions.solidIdentityProvider ?? (await promptIdp()),
+      inputOptions.solidIdentityProvider ??
+      (await promptSolidIdentityProvider()),
     registrationType:
-      inputOptions.registrationType ?? (await promptRegistration()),
-    applicationName: inputOptions.applicationName ?? (await promptClientName()),
+      inputOptions.registrationType ?? (await promptRegistrationType()),
+    applicationName:
+      inputOptions.applicationName ?? (await promptApplicationName()),
   };
   const port = argv.port ?? (await promptPort());
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -91,7 +91,8 @@ export const promptClientName = async () =>
 
 const PROMPT_PORT = {
   type: "number",
-  message: "On what port should the identity provider return the token?",
+  message:
+    "@inrupt/generate-oidc-token will start a local web server, in order for the Solid Identity Provider to redirect the user back after they log in. To what port should this local server be bound?",
   name: "port",
   default: 3001,
   validate: async (input: unknown) => {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -24,30 +24,35 @@ import inquirer from "inquirer";
 
 const PROMPT_IDP_LIST = {
   type: "list",
-  message: "What Identity Provider do you want to register your app to?",
+  message: "What Solid Identity Provider do you want to register your app to?",
   name: "identityProvider",
   choices: [
     { name: IDP_POD_INRUPT },
     { name: IDP_POD_COMPAT },
-    { name: "My Identity provider is not on the list.", value: undefined },
+    {
+      name: "My Solid Identity provider is not on the list.",
+      value: undefined,
+    },
   ],
 };
 
 const PROMPT_IDP_CUSTOM_INPUT = {
   type: "input",
   message:
-    "What is the URL of the Identity Provider you want to register your app to?",
-  name: "identityProvider",
+    "What is the URL of the Solid Identity Provider you want to register your app to?",
+  name: "solidIdentityProvider",
   default: "",
 };
 
 export async function promptIdp(): Promise<string> {
-  let { identityProvider } = await inquirer.prompt([PROMPT_IDP_LIST]);
-  if (identityProvider === undefined) {
-    identityProvider = (await inquirer.prompt([PROMPT_IDP_CUSTOM_INPUT]))
-      .identityProvider;
+  let { identityProvider: solidIdentityProvider } = await inquirer.prompt([
+    PROMPT_IDP_LIST,
+  ]);
+  if (solidIdentityProvider === undefined) {
+    solidIdentityProvider = (await inquirer.prompt([PROMPT_IDP_CUSTOM_INPUT]))
+      .solidIdentityProvider;
   }
-  return identityProvider;
+  return solidIdentityProvider;
 }
 
 const PROMPT_REGISTRATION_TYPE = {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -33,7 +33,8 @@ const PROMPT_IDP_LIST = {
     { name: IDENTITY_PROVIDER_INRUPT_PROD },
     { name: IDENTITY_PROVIDER_INRUPT_PROD_COMPAT },
     {
-      name: "My Solid Identity provider is not on the list.",
+      name:
+        "My Solid Identity provider is not on the list - please contact 'developer-support@inrupt.com' if you'd like to discuss adding a new provider.",
       value: undefined,
     },
   ],
@@ -42,7 +43,7 @@ const PROMPT_IDP_LIST = {
 const PROMPT_IDP_CUSTOM_INPUT = {
   type: "input",
   message:
-    "What is the URL of the Solid Identity Provider you want to register your app to?",
+    "What is the URL of the Solid Identity Provider you wish to register your application with?",
   name: "solidIdentityProvider",
   default: "",
 };
@@ -81,7 +82,7 @@ export const promptRegistrationType = async () =>
 
 const PROMPT_CLIENT_NAME = {
   type: "input",
-  message: "What is the name of the app you are registering?",
+  message: "What is the name of the application you are registering?",
   name: "clientName",
   default: undefined,
 };
@@ -97,7 +98,7 @@ const PROMPT_PORT = {
   default: 3001,
   validate: async (input: unknown) => {
     if (!input || (input as number) < 0 || (input as number) >= 65536) {
-      return `The port must be a number in the [0;65536[ range, received [${input}].`;
+      return `The port must be a number between 0 and 65536, we received [${input}].`;
     }
     return true;
   },

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { IDP_POD_COMPAT, IDP_POD_INRUPT } from "./constants";
+import inquirer from "inquirer";
+
+const PROMPT_IDP_LIST = {
+  type: "list",
+  message: "What Identity Provider do you want to register your app to?",
+  name: "identityProvider",
+  choices: [
+    { name: IDP_POD_INRUPT },
+    { name: IDP_POD_COMPAT },
+    { name: "My Identity provider is not on the list.", value: undefined },
+  ],
+};
+
+const PROMPT_IDP_CUSTOM_INPUT = {
+  type: "input",
+  message:
+    "What is the URL of the Identity Provider you want to register your app to?",
+  name: "identityProvider",
+  default: "",
+};
+
+export async function promptIdp(): Promise<string> {
+  let { identityProvider } = await inquirer.prompt([PROMPT_IDP_LIST]);
+  if (identityProvider === undefined) {
+    identityProvider = (await inquirer.prompt([PROMPT_IDP_CUSTOM_INPUT]))
+      .identityProvider;
+  }
+  return identityProvider;
+}
+
+const PROMPT_REGISTRATION_TYPE = {
+  type: "list",
+  message:
+    "Do you want your app to go through static, or dynamic registration?",
+  name: "registrationType",
+  choices: [
+    {
+      name: "Static: more manual steps, but longer-lived credentials",
+      value: "static",
+    },
+    {
+      name: "Dynamic: less configuration, but credentials expire quicker.",
+      value: "dynamic",
+    },
+  ],
+  default: "dynamic",
+};
+
+export const promptRegistration = async () =>
+  (await inquirer.prompt([PROMPT_REGISTRATION_TYPE])).registrationType;
+
+const PROMPT_CLIENT_NAME = {
+  type: "input",
+  message: "What is the name of the app you are registering?",
+  name: "clientName",
+  default: undefined,
+};
+
+export const promptClientName = async () =>
+  (await inquirer.prompt([PROMPT_CLIENT_NAME])).clientName;
+
+const PROMPT_PORT = {
+  type: "number",
+  message: "On what port should the identity provider return the token?",
+  name: "port",
+  default: 3001,
+};
+
+export const promptPort = async () =>
+  (await inquirer.prompt([PROMPT_PORT])).port;
+
+const PROMPT_CLIENT_INFO = [
+  {
+    type: "input",
+    message: "What is your registered client ID?",
+    name: "clientId",
+  },
+  {
+    type: "input",
+    message: "What is your registered client secret?",
+    name: "clientSecret",
+  },
+];
+export const promptStaticClientInfo = async () =>
+  inquirer.prompt(PROMPT_CLIENT_INFO);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -86,10 +86,16 @@ const PROMPT_PORT = {
   message: "On what port should the identity provider return the token?",
   name: "port",
   default: 3001,
+  validate: async (input: unknown) => {
+    if (!input || (input as number) < 0 || (input as number) >= 65536) {
+      return `The port must be a number in the [0;65536[ range, received [${input}].`;
+    }
+    return true;
+  },
 };
 
 export const promptPort = async () =>
-  (await inquirer.prompt([PROMPT_PORT])).port;
+  parseInt((await inquirer.prompt([PROMPT_PORT])).port);
 
 const PROMPT_CLIENT_INFO = [
   {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -19,7 +19,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { IDP_POD_COMPAT, IDP_POD_INRUPT } from "./constants";
+import {
+  IDENTITY_PROVIDER_INRUPT_PROD_COMPAT,
+  IDENTITY_PROVIDER_INRUPT_PROD,
+} from "./constants";
 import inquirer from "inquirer";
 
 const PROMPT_IDP_LIST = {
@@ -27,8 +30,8 @@ const PROMPT_IDP_LIST = {
   message: "What Solid Identity Provider do you want to register your app to?",
   name: "identityProvider",
   choices: [
-    { name: IDP_POD_INRUPT },
-    { name: IDP_POD_COMPAT },
+    { name: IDENTITY_PROVIDER_INRUPT_PROD },
+    { name: IDENTITY_PROVIDER_INRUPT_PROD_COMPAT },
     {
       name: "My Solid Identity provider is not on the list.",
       value: undefined,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -47,7 +47,7 @@ const PROMPT_IDP_CUSTOM_INPUT = {
   default: "",
 };
 
-export async function promptIdp(): Promise<string> {
+export async function promptSolidIdentityProvider(): Promise<string> {
   let { identityProvider: solidIdentityProvider } = await inquirer.prompt([
     PROMPT_IDP_LIST,
   ]);
@@ -76,7 +76,7 @@ const PROMPT_REGISTRATION_TYPE = {
   default: "dynamic",
 };
 
-export const promptRegistration = async () =>
+export const promptRegistrationType = async () =>
   (await inquirer.prompt([PROMPT_REGISTRATION_TYPE])).registrationType;
 
 const PROMPT_CLIENT_NAME = {
@@ -86,7 +86,7 @@ const PROMPT_CLIENT_NAME = {
   default: undefined,
 };
 
-export const promptClientName = async () =>
+export const promptApplicationName = async () =>
   (await inquirer.prompt([PROMPT_CLIENT_NAME])).clientName;
 
 const PROMPT_PORT = {


### PR DESCRIPTION
This adds an interactive prompt to complete options that are mandatory,
but not specified as CLI parameters.

Currently, the user is prompted for:
- The desired type of registration, and in the static case for client ID and secret
- The client name
- The Solid Identity Provider

Note that I didn't add automated tests yet, I wanted to get something released today that I tested manually, and I'll add proper tests after the holidays (especially tests mimicking user input can be quite time consuming)

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).