### PR TITLE
Clarify static registration requirements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,25 +109,20 @@ async function main(): Promise<void> {
     let clientInfo;
     if (validatedOptions.registrationType === "static") {
       console.log(
-        `Please perform static registration of your application at the Solid Identity Provider [${validatedOptions.solidIdentityProvider}].`
+        `An admin of the server should have registered your app with a redirect URL of [${iriBase}],`
       );
-      console.log(
-        `The redirect IRI will be [${iriBase}] (you will need this information when registering your application).`
-      );
-      console.log(
-        "At the end of the registration process, you should get a client ID and secret."
-      );
+      console.log("and have provided you with a client ID and secret.");
       clientInfo = await promptStaticClientInfo();
       loginOptions.clientId = clientInfo.clientId;
       loginOptions.clientSecret = clientInfo.clientSecret;
     }
 
     console.log(
-      `Logging into Solid Identity Provider  ${validatedOptions.solidIdentityProvider} to get a refresh token.`
+      `Logging in to Solid Identity Provider  ${validatedOptions.solidIdentityProvider} to get a refresh token.`
     );
     session.login(loginOptions).catch((e) => {
       throw new Error(
-        `Logging into Solid Identity Provider [${
+        `Logging in to Solid Identity Provider [${
           validatedOptions.solidIdentityProvider
         }] failed: ${e.toString()}`
       );

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -27,7 +27,7 @@ import inquirer from "inquirer";
 
 const PROMPT_IDP_LIST = {
   type: "list",
-  message: "What Solid Identity Provider do you want to register your app to?",
+  message: "What Solid Identity Provider do you want to log in to?",
   name: "identityProvider",
   choices: [
     { name: IDENTITY_PROVIDER_INRUPT_PROD },
@@ -43,7 +43,7 @@ const PROMPT_IDP_LIST = {
 const PROMPT_IDP_CUSTOM_INPUT = {
   type: "input",
   message:
-    "What is the URL of the Solid Identity Provider you wish to register your application with?",
+    "What is the URL of the Solid Identity Provider you wish to log in to?",
   name: "solidIdentityProvider",
   default: "",
 };
@@ -62,16 +62,16 @@ export async function promptSolidIdentityProvider(): Promise<string> {
 const PROMPT_REGISTRATION_TYPE = {
   type: "list",
   message:
-    "Do you want your app to go through static, or dynamic registration?",
+    "Has your app been pre-registered by the administrator of the Pod server you are signing in to?",
   name: "registrationType",
   choices: [
     {
-      name: "Static: more manual steps, but longer-lived credentials",
-      value: "static",
+      name: "No.",
+      value: "dynamic",
     },
     {
-      name: "Dynamic: less configuration, but credentials expire quicker.",
-      value: "dynamic",
+      name: "Yes, and I have received a client ID and client secret.",
+      value: "static",
     },
   ],
   default: "dynamic",
@@ -93,7 +93,7 @@ export const promptApplicationName = async () =>
 const PROMPT_PORT = {
   type: "number",
   message:
-    "@inrupt/generate-oidc-token will start a local web server, in order for the Solid Identity Provider to redirect the user back after they log in. To what port should this local server be bound?",
+    "@inrupt/generate-oidc-token will start a local web server, to which the Solid Identity Provider can redirect the user back after they log in. On what port do you want to run this server?",
   name: "port",
   default: 3001,
   validate: async (input: unknown) => {


### PR DESCRIPTION
We were under the impression that it was possible for developers to
manually register their app statically, but (at least in ESS) this
can only be done by Pod server administrators. This updates the
prompts to clarify that.
