### PR TITLE
Emit login data as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
+- The result is now displayed as a JSON snippet that may directly be pasted as the
+  input of `@inrupt/solid-client-authn-node` `Session::login` function.
+
 The following sections document changes that have been released already:
 
 ## 0.0.1 - 2020-12-18

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # generate-oidc-token
-This small app aims at help onboarding a script to access private resources on Solid Pods.
+
+This small app generates a token which can be used to login to a Solid Pod.
+
+You will be prompted for information about the app you want to get a token for, then redirected to a web page. After logging in to the web page your terminal console will show a snippet of JSON containing the token and other related data. This JSON can be used as the argument for a call to login().

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,10 +144,15 @@ async function main(): Promise<void> {
       );
     }
     const storedSession = JSON.parse(rawStoredSession);
-    console.log(`\nRefresh token: [${storedSession.refreshToken}]`);
-    console.log(`Client ID: [${storedSession.clientId}]`);
-    console.log(`Client Secret: [${storedSession.clientSecret}]`);
-
+    console.log(`
+These are your login credentials:
+{
+  "refreshToken" : "${storedSession.refreshToken}",
+  "clientId"     : "${storedSession.clientId}",
+  "clientSecret" : "${storedSession.clientSecret}",
+  "oidcIssuer"   : "${storedSession.issuer}",
+}
+`);
     res.send(
       "The tokens have been sent to @inrupt/generate-oidc-token. You can close this window."
     );


### PR DESCRIPTION
For convenience, this emits the login information (refresh token, client
id and secret, OIDC issuer) as a JSON object which can directy be copied
as the input of the `login` function. Copying and pasting individual
properties of the JSON is still possible as well.

# Checklist

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).