### PR TITLE
Put tag slug in GH environment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,11 +15,12 @@ jobs:
   prepare-deployment:
     runs-on: ubuntu-20.04
     outputs:
+      tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
       deployment-id: ${{ fromJson(steps.create-deployment.outputs.data).id }}
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.26
       with:
         route: POST /repos/:repository/deployments
         repository: ${{ github.repository }}
@@ -34,9 +35,10 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Determine npm tag
       id: determine-npm-tag
-      # Remove non-alphanumeric characters
-      # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      run: echo "TAG_SLUG=$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
+      run: |
+        # Remove non-alphanumeric characters
+        # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+        echo "::set-output name=tag-slug::$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')"
 
   publish-npm:
     runs-on: ubuntu-20.04
@@ -47,13 +49,13 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - name: Mark GitHub Deployment as in progress
       id: start-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.26
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        description: "Publishing to npm tag [$TAG_SLUG]…"
+        description: "Publishing to npm tag [${{ needs.prepare-deployment.outputs.tag-slug }}]…"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         state: in_progress
         mediaType: '{"previews": ["flash", "ant-man"]}'
@@ -75,6 +77,8 @@ jobs:
         # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
         VERSION_NR=$(npm version prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP)
         echo "::set-output name=version-nr::$VERSION_NR"
+      env:
+        TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - run: npm ci
     - name: Publish an npm tag for this branch
       run: |
@@ -82,28 +86,29 @@ jobs:
         #     if: secrets.NPM_TOKEN != ''
         # so simply skip the command if the env var is not set:
         if [ -z $NODE_AUTH_TOKEN ]; then echo "No npm token defined; package not published."; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --dist-tag "$TAG_SLUG"; fi
+        if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --tag "$TAG_SLUG"; fi
         if [ -n $NODE_AUTH_TOKEN ]; then echo "Package published. To install, run:"; fi
         if [ -n $NODE_AUTH_TOKEN ]; then echo ""; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then echo "    npx @inrupt/generate-oidc-token@$TAG_SLUG"; fi
+        if [ -n $NODE_AUTH_TOKEN ]; then echo "    npm install @inrupt/generate-oidc-token@$TAG_SLUG"; fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.26
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        environment_url: 'https://www.npmjs.com/package/@inrupt/generate-oidc-token/v/$TAG_SLUG'
-        description: "Published to npm. To install, run: npm install @inrupt/generate-oidc-token@$TAG_SLUG"
+        environment_url: 'https://www.npmjs.com/package/@inrupt/generate-oidc-token/v/${{ needs.prepare-deployment.outputs.tag-slug }}'
+        description: "Published to npm. To install, run: npm install @inrupt/generate-oidc-token@${{ needs.prepare-deployment.outputs.tag-slug }}"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         mediaType: '{"previews": ["flash", "ant-man"]}'
         state: success
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.26
       if: failure()
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
@@ -116,3 +121,8 @@ jobs:
         state: failure
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Waiting for npm CDNs to update...
+      run: |
+        echo "Giving npm some time to make the newly-published package available…"
+        sleep 5m
+        echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,6 @@ jobs:
   prepare-deployment:
     runs-on: ubuntu-20.04
     outputs:
-      tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
       deployment-id: ${{ fromJson(steps.create-deployment.outputs.data).id }}
     steps:
     - name: Create GitHub Deployment
@@ -35,10 +34,9 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Determine npm tag
       id: determine-npm-tag
-      run: |
-        # Remove non-alphanumeric characters
-        # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-        echo "::set-output name=tag-slug::$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')"
+      # Remove non-alphanumeric characters
+      # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+      run: echo "TAG_SLUG=$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
 
   publish-npm:
     runs-on: ubuntu-20.04
@@ -55,7 +53,7 @@ jobs:
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        description: "Publishing to npm tag [${{ needs.prepare-deployment.outputs.tag-slug }}]…"
+        description: "Publishing to npm tag [$TAG_SLUG]…"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         state: in_progress
         mediaType: '{"previews": ["flash", "ant-man"]}'
@@ -77,8 +75,6 @@ jobs:
         # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
         VERSION_NR=$(npm version prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP)
         echo "::set-output name=version-nr::$VERSION_NR"
-      env:
-        TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - run: npm ci
     - name: Publish an npm tag for this branch
       run: |
@@ -86,13 +82,12 @@ jobs:
         #     if: secrets.NPM_TOKEN != ''
         # so simply skip the command if the env var is not set:
         if [ -z $NODE_AUTH_TOKEN ]; then echo "No npm token defined; package not published."; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --tag "$TAG_SLUG"; fi
+        if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --dist-tag "$TAG_SLUG"; fi
         if [ -n $NODE_AUTH_TOKEN ]; then echo "Package published. To install, run:"; fi
         if [ -n $NODE_AUTH_TOKEN ]; then echo ""; fi
         if [ -n $NODE_AUTH_TOKEN ]; then echo "    npx @inrupt/generate-oidc-token@$TAG_SLUG"; fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - name: Mark GitHub Deployment as successful
       uses: octokit/request-action@v2.x
       with:
@@ -100,8 +95,8 @@ jobs:
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        environment_url: 'https://www.npmjs.com/package/@inrupt/generate-oidc-token/v/${{ needs.prepare-deployment.outputs.tag-slug }}'
-        description: "Published to npm. To install, run: npm install @inrupt/generate-oidc-token@${{ needs.prepare-deployment.outputs.tag-slug }}"
+        environment_url: 'https://www.npmjs.com/package/@inrupt/generate-oidc-token/v/$TAG_SLUG'
+        description: "Published to npm. To install, run: npm install @inrupt/generate-oidc-token@$TAG_SLUG"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         mediaType: '{"previews": ["flash", "ant-man"]}'
         state: success


### PR DESCRIPTION
This changes the previous approach, where the tag slug was collected
from the output of a job and injected into other jobs, so that the one
job that generates the tag slug directly writes it in the GH runner
environment.