### PR TITLE
Prevent NPM deployments on dependabot PR

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   unpublish-npm:
     runs-on: ubuntu-20.04
-    if: github.event.ref_type == 'branch'
+    if: ${{github.event.ref_type == 'branch' && github.actor != 'dependabot[bot]'}} 
     steps:
     - name: Prepare for unpublication from npm
       uses: actions/setup-node@v2.1.5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
       deployment-id: ${{ fromJson(steps.create-deployment.outputs.data).id }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
@@ -43,6 +44,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment]
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       version-nr: ${{ steps.determine-npm-version.outputs.version-nr }}
     steps:


### PR DESCRIPTION
Dependabot doesn't have access to GH secrets, so it cannot push packages
to NPM. This prevents the CD job from running at all for commits pushed
by dependabot.