### PR TITLE
Auth upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfix
+
+- Upgrade dependencies to be compatible with the latest ID broker from ESS. This
+  also fixes a TS change that was breaking the CLI tool.
+
 The following sections document changes that have been released already:
 
 ## 0.1.1 - 2021-03-12

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.13.14",
         "@inrupt/prism-react-components": "^0.13.1-alpha.2",
-        "@inrupt/solid-client-authn-node": "^1.7.2",
+        "@inrupt/solid-client-authn-node": "^1.7.4",
         "@inrupt/solid-ui-react": "^2.1.1",
         "@material-ui/core": "^4.11.3",
         "@solid/lit-prism-patterns": "^0.13.1-alpha.2",
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.7.2.tgz",
-      "integrity": "sha512-McLxf4h5DAZMsfVkJxqtRyvjDAmN6V2NQjDpxUkpER3EqiRPpne1qkEpj5NKagEE5T0I02VUx+mbfn/xbblWaQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.7.4.tgz",
+      "integrity": "sha512-1aAly3I3H8jNr3ci9MgkKNj+bagGiXwrQ3RETboDVaLXiNkZ/4eIz8ccGD3+XXEP3Kr126u+amt+V65HY3JmRg==",
       "dependencies": {
         "@inrupt/solid-common-vocab": "^0.5.3",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -796,11 +796,11 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.7.2.tgz",
-      "integrity": "sha512-25hM34j/r3MtfC6mGl/E8BoeLoLD1/Fq2slZM+GsYClNM53bDEeGnur4wCMqIKROvPZS2wOgKoODzArwVLX5sA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.7.4.tgz",
+      "integrity": "sha512-2vTcTP9zVk6yr2Az036tf1wkHUo79tMzY1j/QVvjrqPmvrohpHTEsQHymavpby03gGjgXvH4jNQ3OB662qtYYQ==",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^1.7.2",
+        "@inrupt/solid-client-authn-core": "^1.7.4",
         "@types/node": "^14.14.14",
         "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.0.6",
@@ -8016,14 +8016,17 @@
       }
     },
     "node_modules/jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "dependencies": {
         "@panva/asn1.js": "^1.0.0"
       },
       "engines": {
         "node": ">=10.13.0 < 13 || >=13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -14323,9 +14326,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.7.2.tgz",
-      "integrity": "sha512-McLxf4h5DAZMsfVkJxqtRyvjDAmN6V2NQjDpxUkpER3EqiRPpne1qkEpj5NKagEE5T0I02VUx+mbfn/xbblWaQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.7.4.tgz",
+      "integrity": "sha512-1aAly3I3H8jNr3ci9MgkKNj+bagGiXwrQ3RETboDVaLXiNkZ/4eIz8ccGD3+XXEP3Kr126u+amt+V65HY3JmRg==",
       "requires": {
         "@inrupt/solid-common-vocab": "^0.5.3",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -14337,11 +14340,11 @@
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.7.2.tgz",
-      "integrity": "sha512-25hM34j/r3MtfC6mGl/E8BoeLoLD1/Fq2slZM+GsYClNM53bDEeGnur4wCMqIKROvPZS2wOgKoODzArwVLX5sA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.7.4.tgz",
+      "integrity": "sha512-2vTcTP9zVk6yr2Az036tf1wkHUo79tMzY1j/QVvjrqPmvrohpHTEsQHymavpby03gGjgXvH4jNQ3OB662qtYYQ==",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.7.2",
+        "@inrupt/solid-client-authn-core": "^1.7.4",
         "@types/node": "^14.14.14",
         "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.0.6",
@@ -19986,9 +19989,9 @@
       }
     },
     "jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@babel/core": "^7.13.14",
     "@inrupt/prism-react-components": "^0.13.1-alpha.2",
-    "@inrupt/solid-client-authn-node": "^1.7.2",
+    "@inrupt/solid-client-authn-node": "^1.7.4",
     "@inrupt/solid-ui-react": "^2.1.1",
     "@material-ui/core": "^4.11.3",
     "@solid/lit-prism-patterns": "^0.13.1-alpha.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest --passWithNoTests",
-    "build": "tsc && next build",
+    "build": "tsc",
     "dev": "next dev",
     "prepublishOnly": "npm run build",
     "check-licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,7 +58,7 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "allowJs": true,
     "skipLibCheck": true,
-    "noEmit": true,
+    "noEmit": false,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
This upgrades the dependencies to be compatible with the latest ID broker. It also fixes the TS configuration that had been previously mangled.

This will allow users to get refresh tokens before https://github.com/inrupt/generate-oidc-token/pull/105 is sorted out, and this can be used alongside https://github.com/inrupt/solid-client-authn-js/pull/1284.

- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).