### PR TITLE
0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+## 0.1.3 - 2021-08-13
+
+### Bugfix
+
+- Upgraded dependencies to get a bugfix to resolve "invalid client_credentials" issue.
+
 ## 0.1.2 - 2021-04-20
 
 ### Bugfix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/generate-oidc-token",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/generate-oidc-token",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A small app to help scripts access private resources on Solid Pods",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
This PR bumps the version to 0.1.3.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
