### PR TITLE
Remove pod compat from prompt IDP list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+- Removed `https://broker.pod-compat.inrupt.com` from prompt list of IDPs.
+
 ## 0.1.3 - 2021-08-13
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+### Patches
+
 - Removed `https://broker.pod-compat.inrupt.com` from prompt list of IDPs.
 
 ## 0.1.3 - 2021-08-13

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,5 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+// eslint-disable-next-line import/prefer-default-export
 export const IDENTITY_PROVIDER_INRUPT_PROD = "https://broker.pod.inrupt.com";
-export const IDENTITY_PROVIDER_INRUPT_PROD_COMPAT =
-  "https://broker.pod-compat.inrupt.com";

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -20,10 +20,7 @@
  */
 
 import inquirer from "inquirer";
-import {
-  IDENTITY_PROVIDER_INRUPT_PROD_COMPAT,
-  IDENTITY_PROVIDER_INRUPT_PROD,
-} from "./constants";
+import { IDENTITY_PROVIDER_INRUPT_PROD } from "./constants";
 
 const PROMPT_IDP_LIST = {
   type: "list",
@@ -31,7 +28,6 @@ const PROMPT_IDP_LIST = {
   name: "identityProvider",
   choices: [
     { name: IDENTITY_PROVIDER_INRUPT_PROD },
-    { name: IDENTITY_PROVIDER_INRUPT_PROD_COMPAT },
     {
       name:
         "My Solid Identity provider is not on the list - please contact 'developer-support@inrupt.com' if you'd like to discuss adding a new provider.",


### PR DESCRIPTION
- Removes `https://broker.pod-compat.inrupt.com` from the list of IDPs in the command line prompt
- Removes `https://broker.pod-compat.inrupt.com` from constants file